### PR TITLE
Remove unnecessary sleep()

### DIFF
--- a/sched-analyzer.c
+++ b/sched-analyzer.c
@@ -264,8 +264,6 @@ int main(int argc, char **argv)
 			fprintf(stderr, "Error polling softirq_rb ring buffer: %d\n", err);
 			break;
 		}
-
-		sleep(1);
 	}
 
 cleanup:


### PR DESCRIPTION
ring_buffer__poll() essentially uses epoll(7) to wait for the data, which plays similar act as sleep() when there has no event.  Not to mention we've already have a 1000ms timeout set in ring_buffer__poll().

Remove the sleep() to prevent potential lose of the event, which exacerbates when the machine is busy.